### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,8 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             ext: '.exe'
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/omnitype/security/code-scanning/3](https://github.com/bniladridas/omnitype/security/code-scanning/3)

To fix the problem, you should set the permissions for the `build` job by adding a `permissions` block under the job definition in `.github/workflows/release.yml`. This block should set permissions to the minimal level required. As the build job mainly checks out code and uploads artifacts, the only necessary permission is `contents: read`, which allows reading repository contents for the checkout action but denies write access.  

**How to make the change:**  
- Edit file: `.github/workflows/release.yml`
- Under the `build:` job (line 114), add a `permissions:` block before `runs-on: ${{ matrix.os }}` (i.e., after line 130 and before line 131).
- Set `contents: read` within that block.

**No changes to imports, methods, or other definitions are required. Only a YAML workflow key addition.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted repository contents permission to read-only for the build job in the release workflow, applying to Linux, macOS, and Windows builds.

* **Chores**
  * Updated CI configuration to use reduced permissions for the build job.
  * No changes to build steps or targets; release workflow behavior remains the same for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->