### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,8 @@ jobs:
 
   publish:
     name: Publish to crates.io
+    permissions:
+      contents: write
     needs: [release, build]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Potential fix for [https://github.com/bniladridas/omnitype/security/code-scanning/8](https://github.com/bniladridas/omnitype/security/code-scanning/8)

To fix this problem, we should explicitly add a `permissions` block to the `publish` job in `.github/workflows/release.yml` to restrict the GITHUB_TOKEN to the minimum required privilege. The publish job's steps (checkout, git config, git commit, git push, cargo publish) require reading repository contents, and in some cases, pushing changes. However, if `git push` is required, a `contents: write` permission may be needed. If the only publish step is `cargo publish` to crates.io (which uses a separate token), then `contents: read` is sufficient. To follow the CodeQL recommendation, we will conservatively set `contents: read`, unless the workflow actually pushes changes to the repo (e.g., updating `Cargo.lock`). Since there is a conditional `git push` in the sequence ("git push || echo"), we should use `contents: write` for this job. Therefore, add the following block at the same level as `runs-on` in the `publish` job:

```yaml
permissions:
  contents: write
```

**Required changes:**  
- Insert the above permissions block in the `publish` job, after `name`.
- No imports or other definitions are required for a YAML workflow change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
